### PR TITLE
security: bronverantwoording losmaken van niet-publieke bestanden

### DIFF
--- a/security/stelselkaart-security-gremia/index.html
+++ b/security/stelselkaart-security-gremia/index.html
@@ -343,25 +343,34 @@ footer{margin-top:40px;padding-top:14px;border-top:1px solid var(--line);color:v
 
 <!-- ============ BRONNEN ============ -->
 <section class="panel" id="p-bronnen">
-  <div class="lead">Deze kaart is opgebouwd uit twee analyses: wat er in de eigen dossiers al bekend was, en zes
-  parallelle online onderzoeksronden. Waar bronnen elkaar tegenspreken is dat hieronder expliciet benoemd in plaats van
+  <div class="lead">Deze kaart is opgebouwd uit zes parallelle onderzoeksronden, elk over een eigen deel van het
+  veld, plus een toets vanuit de dagelijkse praktijk van een gemeentelijke CISO: klopt het beeld met hoe het er van
+  binnenuit uitziet. Waar bronnen elkaar tegenspreken is dat hieronder expliciet benoemd in plaats van
   gladgestreken.</div>
 
-  <h2>Waar de gegevens vandaan komen</h2>
-  <div class="scroll"><table class="t">
-    <thead><tr><th style="width:34%">Bestand in <code>bronnen\</code></th><th>Inhoud</th></tr></thead>
-    <tbody>
-      <tr><td>01 Analyse intern - eigen dossiers</td><td>Volledige lezing van <code>Samenwerkingen CISO\</code> (199 bestanden, 13 dossiermappen), de dossier-catalogus van het werk-brein en de bordkaarten</td></tr>
-      <tr><td>02 Cluster gemeentelijk en decentraal</td><td>IBD, VNG, GGI-Veilig, ENSIA, BIO2-governance, CISO-netwerken, regionale samenwerking, IPO, Unie van Waterschappen, NIPV, BZK</td></tr>
-      <tr><td>03 Cluster NDS, EU en stelselkritiek</td><td>NDS-governance, de Europese laag, en de stelselkritiek van CSR, Raad van State, WRR, Algemene Rekenkamer, ROB, het Oldengarm-rapport en de VNG-consultatiereactie</td></tr>
-      <tr><td>04 Cluster operationele coalities</td><td>Cyberweerbaarheidsnetwerk, NRN, Anti-DDoS-Coalitie, NBIP en NaWas, Connect2Trust, Abuse Information Exchange, FIRST, Trusted Introducer</td></tr>
-      <tr><td>05 Analyse - overlap, concurrentie en gaten</td><td>De analyselaag onder het conclusie-tabblad</td></tr>
-      <tr><td>06 Cluster nationaal</td><td>NCSC organisatorisch, NCTV, NBV en de diensten, NDN, Cyclotron, House of Cyber, CIO Rijk en VSSR, NDD en Digilab, Logius en Forum Standaardisatie, politie en OM</td></tr>
-      <tr><td>07 Cluster sectoraal, platforms en regionaal</td><td>Z-CERT, SURF, de CSIRT-aanwijzingen, het ISAC-stelsel, CIP, ECP, HSD, CVD, de regionale cyberweerbaarheidscentra, RSIV, PVO en de randpartijen</td></tr>
-    </tbody>
-  </table></div>
-  <p><small class="src">Elk clusterbestand bevat de volledige bronvermeldingen met URL en datum van raadpleging.
-  Peildatum van alle online bronnen: 10 en 11 augustus 2026.</small></p>
+  <h2>Hoe dit is samengesteld</h2>
+  <p>Het onderzoek liep in zes parallelle ronden, elk over een eigen deel van het veld, plus een ronde over de
+  eigen praktijk als toets of het beeld klopt met hoe het er van binnenuit uitziet:</p>
+  <ul class="tight">
+    <li><b>Gemeentelijk en decentraal</b> &middot; IBD, VNG, GGI-Veilig, ENSIA, BIO2-governance, CISO-netwerken,
+      regionale samenwerking, IPO, Unie van Waterschappen, NIPV, BZK</li>
+    <li><b>Nationaal</b> &middot; NCSC organisatorisch, NCTV, NBV en de diensten, Nationaal Detectie Netwerk,
+      Cyclotron, House of Cyber, CIO Rijk en VSSR, NDD en Digilab, Logius en Forum Standaardisatie, politie en OM</li>
+    <li><b>Sectoraal, platforms en regionaal</b> &middot; Z-CERT, SURF, de CSIRT-aanwijzingen, het ISAC-stelsel,
+      CIP, ECP, HSD, CVD, de regionale cyberweerbaarheidscentra, RSIV, PVO en de randpartijen</li>
+    <li><b>Operationele coalities</b> &middot; Cyberweerbaarheidsnetwerk, Nationaal Respons Netwerk,
+      Anti-DDoS-Coalitie, NBIP en NaWas, Connect2Trust, Abuse Information Exchange, FIRST, Trusted Introducer</li>
+    <li><b>NDS, EU-laag en stelselkritiek</b> &middot; NDS-governance, de Europese laag, en de adviezen van de
+      Cyber Security Raad, de Raad van State, de WRR, de Algemene Rekenkamer en de Raad voor het Openbaar Bestuur,
+      plus het rapport Cyberweerbaarheid binnen gemeentegrenzen en de VNG-consultatiereactie</li>
+    <li><b>Overlapanalyse</b> &middot; de vertaling van functies naar concrete diensten, waaruit de twee
+      overlapweergaven zijn opgebouwd</li>
+  </ul>
+  <p>Bronnen zijn wetgeving en Staatscourant-publicaties, Kamerstukken, en websites en jaarplannen van de
+  betrokken partijen. Elke partij en elke dienst in de dataset heeft een toelichting waarin staat waarop de
+  inschatting berust. <b>Peildatum van alle online bronnen: 10 en 11 augustus 2026.</b></p>
+  <p><small class="src">Waar een uitspraak een interpretatie is en geen feit, staat dat in de tekst benoemd.
+  Waar officiele bronnen elkaar tegenspraken is dat hieronder expliciet gemaakt in plaats van gladgestreken.</small></p>
 
   <h2>Tegenstrijdigheden tussen officiele bronnen</h2>
 
@@ -449,7 +458,7 @@ footer{margin-top:40px;padding-top:14px;border-top:1px solid var(--line);color:v
   <h2>Methodische kanttekeningen</h2>
   <ul class="tight">
     <li>Twee onderzoeksronden liepen tegen zoekbudgetten aan en zijn deels via directe URL-fetches, sitemap-analyse en
-    archiefopnames gedaan. Waar archiefmateriaal is gebruikt, staat de opnamedatum in het clusterbestand.</li>
+    archiefopnames gedaan. Waar archiefmateriaal is gebruikt, staat de opnamedatum bij de betreffende partij vermeld.</li>
     <li>De Trusted Introducer-statussen zijn de stand van 19 januari 2025; de live directory was niet bereikbaar.</li>
     <li>De telling van 29 organisaties over 7 ministeries komt uit onderzoek van de Universiteit Leiden en is geciteerd via
     het nieuwsbericht van 19 mei 2026; de onderliggende publicatie is niet geverifieerd.</li>


### PR DESCRIPTION
Correctie op #12.

Het tabblad Verantwoording bevatte een tabel met verwijzingen naar bestanden die alleen in de tenant van de opsteller bestaan (`bronnen\01` tot `07`). Voor een lezer hier is dat een verwijzing naar niets. De eerste regel beschreef bovendien de inrichting en omvang van dat interne dossierstelsel, en dat hoort er inhoudelijk niet in.

Vervangen door een beschrijving van **de onderzoeksaanpak**: welke zes ronden er liepen en welk deel van het veld elk dekte, welke bronsoorten zijn gebruikt (wetgeving, Staatscourant, Kamerstukken, websites en jaarplannen van de partijen zelf), en de peildatum. Wie wil weten waarop een specifieke inschatting berust, vindt dat in de toelichting bij de partij of de dienst zelf, en die staan in `data/partijen.json` en `data/diensten.json`.

De twee benoemde tegenstrijdigheden tussen officiële bronnen blijven ongewijzigd staan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)