### PR TITLE
security: GitHub-links in de stelselkaart absoluut maken

### DIFF
--- a/security/stelselkaart-security-gremia/index.html
+++ b/security/stelselkaart-security-gremia/index.html
@@ -213,10 +213,12 @@ footer{margin-top:40px;padding-top:14px;border-top:1px solid var(--line);color:v
   <b>Open dataset uit de kennisbank van security-commons-nl.</b> 82 partijen en 19 concrete diensten die samen de
   digitale weerbaarheid van de Nederlandse overheid organiseren. <b>Peildatum 11 augustus 2026</b>, vier dagen voor
   inwerkingtreding van de Cyberbeveiligingswet: meerdere aanwijzingen waren toen nog niet rond. Klopt er iets niet
-  meer, of mist er een partij? <a href="../../../../issues/new/choose">Open een issue</a> of corrigeer een regel in
-  <a href="data/partijen.json">de JSON</a>. De analyse van onnodige overlap en concurrentie is bewust nog niet
-  gepubliceerd: feiten zijn van iedereen, een oordeel over het stelsel is sterker als het van meer dan een
-  gemeente komt. <a href="README.md">Meer daarover in de README</a>.
+  meer, mist er een partij, of wordt er al aan iets gewerkt dat hier als leeg staat?
+  <b>Twee routes:</b> <a href="https://github.com/security-commons-nl/kennisbank/issues/new/choose">open een issue</a> (kan met een paar regels, geen kennis van de
+  data nodig) of <a href="https://github.com/security-commons-nl/kennisbank/edit/main/security/stelselkaart-security-gremia/data/partijen.json">wijzig een regel in de dataset</a> (GitHub maakt daar automatisch een
+  voorstel van, jij hoeft geen schrijfrechten te hebben). De analyse van onnodige overlap en concurrentie is bewust
+  nog niet gepubliceerd: feiten zijn van iedereen, een oordeel over het stelsel is sterker als het van meer dan een
+  gemeente komt. <a href="https://github.com/security-commons-nl/kennisbank/blob/main/security/stelselkaart-security-gremia/README.md">Meer daarover in de README</a>.
 </div>
 <nav class="tabs" role="tablist">
   <button role="tab" aria-selected="true" data-t="kaart">Kaart</button>
@@ -468,10 +470,10 @@ footer{margin-top:40px;padding-top:14px;border-top:1px solid var(--line);color:v
 
 <footer>
   Stelselkaart security-gremia &middot; peildatum 11 augustus 2026 &middot; onderdeel van de
-  <a href="../../">kennisbank van security-commons-nl</a> &middot; licentie
-  <a href="../../LICENSE">EUPL-1.2</a> &middot; de onderliggende data staat als JSON in
+  <a href="https://github.com/security-commons-nl/kennisbank">kennisbank van security-commons-nl</a> &middot; licentie
+  <a href="https://github.com/security-commons-nl/kennisbank/blob/main/LICENSE">EUPL-1.2</a> &middot; de onderliggende data staat als JSON in
   <a href="data/partijen.json">data/partijen.json</a> en <a href="data/diensten.json">data/diensten.json</a>.
-  <b>Klopt er iets niet meer? Open een <a href="../../../../issues/new/choose">issue</a>.</b>
+  <b>Klopt er iets niet meer? Open een <a href="https://github.com/security-commons-nl/kennisbank/issues/new/choose">issue</a>.</b>
   Opgesteld met AI-ondersteuning, feiten geverifieerd op de vermelde bronnen; waar bronnen elkaar tegenspreken is dat expliciet benoemd.
 </footer>
 </div>


### PR DESCRIPTION
De uitnodiging om een correctie in te sturen werkte niet: de GitHub-links stonden als relatief pad in de pagina, terwijl de pagina op github.io staat en de repo op github.com. `../../../../issues/new/choose` belandde daardoor op `github.io/issues/new/choose` en gaf een 404. Idem voor de kennisbank- en LICENSE-link in de voettekst; de README-link wees naar het ruwe markdown-bestand.

Nu absolute URL's. De correctieroute is uitgesplitst in twee drempels: een issue openen (alleen melden) of de dataset-editor (regel zelf aanpassen, werkt ook zonder schrijfrechten omdat GitHub er een voorstel van maakt). De banner vraagt nu ook expliciet naar het derde soort correctie: iets dat hier als leeg staat terwijl er al aan gewerkt wordt.

Gegenereerd met `tools/genereer-publieke-html.py`; alleen `index.html` verandert, de datasets zijn byte-identiek.

🤖 Generated with [Claude Code](https://claude.com/claude-code)