### PR TITLE
security: stelselkaart bijwerken na de eerste externe review

### DIFF
--- a/security/stelselkaart-security-gremia/README.md
+++ b/security/stelselkaart-security-gremia/README.md
@@ -1,13 +1,22 @@
 # Stelselkaart security-gremia
 
 Wie organiseert de digitale weerbaarheid van de Nederlandse overheid, en hoe verhouden die partijen
-zich tot elkaar? Deze map bevat een **open dataset** van 82 partijen en 19 concrete diensten:
+zich tot elkaar? Deze map bevat een **open dataset** van 83 partijen en 19 concrete diensten:
 van designated clubs als de IBD tot publiek-private platforms, plus de Europese laag als context.
 
 > **Peildatum 11 augustus 2026.** Dit is een momentopname van een stelsel dat op dat moment hard in
 > beweging was. De Cyberbeveiligingswet trad op 15 augustus 2026 in werking, meerdere CSIRT-aanwijzingen
 > waren nog niet rond, en de OKTT-status stond op het punt te vervallen. **Kloppen er dingen niet meer?
-> Open een [issue](../../../issues/new/choose).** Dat is precies waarvoor deze dataset open is.
+> Open een [issue](https://github.com/security-commons-nl/kennisbank/issues/new/choose).** Dat is precies
+> waarvoor deze dataset open is.
+
+> **Bijgewerkt 13 augustus 2026, na de eerste externe review uit de sector.** Drie aanscherpingen:
+> de vier gaten in de dienstentabel maken nu onderscheid tussen *niets belegd* en *wel aan gewerkt, en
+> door wie* (een nul betekende hier ten onrechte dat er niets gebeurde) · bij de RDI staat nu in de
+> omschrijving zelf dat BZK de bevoegde autoriteit is en de RDI het toezicht uitvoert · **regionale
+> samenwerkingsverbanden** zijn als categorie opgenomen, met RSIV Den Haag als uitgewerkt voorbeeld,
+> omdat er landelijk meer van zulke verbanden bestaan dan dat ene. Wat nog ontbreekt is het landelijke
+> beeld: welke verbanden er zijn en welke gemeenten erbuiten vallen.
 
 ## Waarom dit bestaat
 
@@ -22,8 +31,8 @@ resultaat te delen in plaats van in een la te leggen.
 | Bestand | Inhoud |
 |---|---|
 | **`index.html`** | **De leesbare weergave.** Open het bestand in je browser, of via GitHub Pages direct de map-URL. Vijf visualisaties, een filterbaar overzicht van alle partijen, en de bronverantwoording. Offline te openen, geen externe afhankelijkheden |
-| `data/partijen.json` | 82 partijen met laag, mandaatsoort, functies, toegankelijkheid voor een gemeente, omschrijving en toelichting |
-| `data/diensten.json` | 19 concrete diensten met wie ze levert, inclusief 4 diensten die **niemand** levert |
+| `data/partijen.json` | 83 partijen met laag, mandaatsoort, functies, toegankelijkheid voor een gemeente, omschrijving en toelichting |
+| `data/diensten.json` | 19 concrete diensten met wie ze levert, inclusief **4 gaten**. Per gat staat in `gat_soort` of er niets is belegd of dat er wel aan gewerkt wordt, en in dat laatste geval staat in `werk_in_uitvoering` door wie |
 
 Beide JSON-bestanden bevatten een `meta`-blok met het vocabulaire, zodat de codes zelfverklarend zijn.
 
@@ -60,8 +69,16 @@ wordt overlap hard aanwijsbaar, en worden de gaten zichtbaar.
 | 6 | Collectieve security-inkoop | **0** |
 | 6 | Handreikingen en templates | 2 |
 
-**De vier gaten, waar niemand staat:** OT-normering · een landelijke weerbaarheidsmeting van gemeenten ·
-ketenregie tussen organisaties · de opvolging van de OKTT-status.
+**De vier gaten, in twee soorten.** Waar helemaal niets is belegd: een landelijke weerbaarheidsmeting van
+gemeenten (de Algemene Rekenkamer heeft geen mandaat over gemeenten, lokale rekenkamers leveren geen
+landelijk beeld, ENSIA levert data maar geen analyse) en de opvolging van de OKTT-status (vervalt met de
+Cbw, opvolging niet uitgewerkt). Waar geen kader is vastgesteld maar wel aan gewerkt wordt: **OT-normering**
+(IBD en VNG maken objectbaselines voor de 23 meest voorkomende OT-objecten; tijdpad en vorm nog niet
+publiek) en **ketenregie tussen organisaties** (NDS-versneller 5.4 levert een begrippenkader, een centraal
+register staat expliciet niet in scope).
+
+Dat onderscheid is er sinds 13 augustus 2026 en het is geen detail: een nul in een tabel leest als "niemand
+doet iets", en dat deed het werk van anderen tekort.
 
 **Drie observaties die uit de data volgen:**
 
@@ -87,7 +104,7 @@ CIP en Connect2Trust ook, terwijl ze in de functie-indeling in dezelfde categori
 Het veld `toegang_gemeente` geeft aan of je er als gemeente zelf bij kunt:
 
 - **`direct`** (38 partijen) — zelf terecht, lid worden of een dienst afnemen
-- **`indirect`** (16 partijen) — alleen via een koepel of schakelorganisatie, meestal de IBD
+- **`indirect`** (17 partijen) — alleen via een koepel of schakelorganisatie, meestal de IBD
 - **`gesloten`** (28 partijen) — niet toegankelijk voor een gemeente
 
 Dat laatste getal is op zichzelf een bevinding: ruim een derde van het stelsel is voor een gemeente
@@ -116,8 +133,11 @@ door iedereen gecorrigeerd worden. De duiding, met de volledige analyse van over
 concurrentie en gaten, volgt zodra er een tweede maintainer meetekent. Dat is geen slag om de arm maar
 een principe: een oordeel over het stelsel is sterker als het van meer dan één gemeente komt.
 
-**Meedoen?** Open een [issue](../../../issues/new/choose) of een discussion. Corrigeren van één regel in
-een JSON-bestand is genoeg om bij te dragen; je hoeft geen visualisatie te bouwen.
+**Meedoen?** Open een [issue](https://github.com/security-commons-nl/kennisbank/issues/new/choose) of een
+discussion, of wijzig direct
+[een regel in de dataset](https://github.com/security-commons-nl/kennisbank/edit/main/security/stelselkaart-security-gremia/data/partijen.json).
+Dat laatste werkt ook zonder schrijfrechten: GitHub maakt er automatisch een voorstel van. Eén regel
+corrigeren is genoeg om bij te dragen, je hoeft geen visualisatie te bouwen.
 
 ## Hergebruik
 
@@ -131,5 +151,6 @@ Bas Stevens.
 
 ## Licentie
 
-[EUPL-1.2](../../LICENSE) — vrij te hergebruiken en aan te passen. Feedback en verbeteringen welkom via
-de [kennisbank](../../).
+[EUPL-1.2](https://github.com/security-commons-nl/kennisbank/blob/main/LICENSE), vrij te hergebruiken en
+aan te passen. Feedback en verbeteringen welkom via de
+[kennisbank](https://github.com/security-commons-nl/kennisbank).

--- a/security/stelselkaart-security-gremia/data/diensten.json
+++ b/security/stelselkaart-security-gremia/data/diensten.json
@@ -54,6 +54,8 @@
       ],
       "aantal": 8,
       "is_gat": false,
+      "gat_soort": null,
+      "werk_in_uitvoering": [],
       "duiding": "De goedkoopste functie om op te pakken en de moeilijkste om je op te onderscheiden. Acht aanbieders voor grotendeels dezelfde persoon, die er hooguit twee kan volgen. Zeven van de acht hebben geen wettelijke basis, dus niemand kan hier opruimen."
     },
     {
@@ -68,6 +70,8 @@
       ],
       "aantal": 6,
       "is_gat": false,
+      "gat_soort": null,
+      "werk_in_uitvoering": [],
       "duiding": "Het Oldengarm-rapport noemt dit zelf wildgroei. Oefencapaciteit is de schaarste: een gemeente maakt het crisisteam twee tot drie keer per jaar vrij. Zes aanbieders die om dezelfde dagdelen concurreren leveren netto minder geoefende organisaties op, niet meer."
     },
     {
@@ -82,6 +86,8 @@
       ],
       "aantal": 6,
       "is_gat": false,
+      "gat_soort": null,
+      "werk_in_uitvoering": [],
       "duiding": "Geen enkele partij heeft hier een wettelijk mandaat. Dat verklaart het meervoud: niemand kon het afdwingen, dus begon iedereen zelf. Bovendien zijn de deelnemerslijsten van GGI-Veilig niet publiek, dus je kunt niet eens zien met wie je zou kunnen bundelen."
     },
     {
@@ -96,6 +102,8 @@
       ],
       "aantal": 6,
       "is_gat": false,
+      "gat_soort": null,
+      "werk_in_uitvoering": [],
       "duiding": "Dezelfde onderwerpen worden zes keer uitgeschreven, met verschillende begrippen. De ISMS-handreiking, de thema-uitwerkingen en de syllabi gaan alle drie over BIO2, en het is aan de lezer om te bepalen welke leidend is."
     },
     {
@@ -109,6 +117,8 @@
       ],
       "aantal": 5,
       "is_gat": false,
+      "gat_soort": null,
+      "werk_in_uitvoering": [],
       "duiding": "Hier is meervoud geen versnippering maar arbeidsdeling: vier van de vijf hebben een wettelijk mandaat en een eigen domein (baseline, open standaarden, DigiD, rijksopdrachten). De uitzondering is CIP, dat beheert namens BZK en dus afgeleid gezag heeft."
     },
     {
@@ -122,6 +132,8 @@
       ],
       "aantal": 5,
       "is_gat": false,
+      "gat_soort": null,
+      "werk_in_uitvoering": [],
       "duiding": "Vier van de vijf zijn voor een gemeente niet toegankelijk: het NDN staat alleen open voor Rijk en vitale sectoren, Cyclotron voor diensten en securityleveranciers, en er is geen gemeente-ISAC. Wat overblijft is wat de IBD doorgeeft."
     },
     {
@@ -135,6 +147,8 @@
       ],
       "aantal": 5,
       "is_gat": false,
+      "gat_soort": null,
+      "werk_in_uitvoering": [],
       "duiding": "Vijf stromen over deels dezelfde maatregelen, plus de gemeenteraad en de provincie. ENSIA is in 2017 juist opgericht om dit te bundelen (Single Information, Single Audit) en dat principe is binnen negen jaar weer ondergesneeuwd."
     },
     {
@@ -147,6 +161,8 @@
       ],
       "aantal": 4,
       "is_gat": false,
+      "gat_soort": null,
+      "werk_in_uitvoering": [],
       "duiding": "Vier kanalen, dezelfde registratielogica: domeinen, IP-ranges en AS-nummers. Het risico is hier niet de overlap maar het omgekeerde: de IBD laat haar EASM-contract aflopen en kijkt nog hoe haar informatiepositie geborgd blijft. Je kunt tegelijk dubbel bediend en onbediend raken."
     },
     {
@@ -159,6 +175,8 @@
       ],
       "aantal": 4,
       "is_gat": false,
+      "gat_soort": null,
+      "werk_in_uitvoering": [],
       "duiding": "Vier meetlatten die elkaar niet kennen: SOC-CMM uit het VSSR, SIM3 van Trusted Introducer, de ENSIA-verantwoording en de gap-analyse van de IBD. Geen enkele daarvan levert een landelijk vergelijkbaar beeld op."
     },
     {
@@ -171,6 +189,8 @@
       ],
       "aantal": 4,
       "is_gat": false,
+      "gat_soort": null,
+      "werk_in_uitvoering": [],
       "duiding": "Vier systematieken naast elkaar: de NDS-versneller, de IBD-methodiek voor gemeenten, de TBB-lijn via ABRO en BVA, en de aanpak vitaal. Precies daarom is het eerste product van versneller 5.4 een begrippenkader geworden en geen register."
     },
     {
@@ -182,6 +202,8 @@
       ],
       "aantal": 3,
       "is_gat": false,
+      "gat_soort": null,
+      "werk_in_uitvoering": [],
       "duiding": "Drie vertaallagen op hetzelfde kader. De praktijk heeft hier al gekozen zonder dat het stelsel dat heeft geformaliseerd: in de onderzochte gemeentelijke praktijk wordt de BIO2-Excel van CIP intensief gebruikt, terwijl de thema-uitwerkingen en de SIVA-methodiek in de dossiers nergens voorkomen."
     },
     {
@@ -193,6 +215,8 @@
       ],
       "aantal": 3,
       "is_gat": false,
+      "gat_soort": null,
+      "werk_in_uitvoering": [],
       "duiding": "De duurste onopgeloste vraag van het hele overzicht. Het NCSC heeft het wettelijke mandaat maar tijdelijk, de IBD heeft de praktijk en de relaties maar geen aanwijzing, en het NRN is als opschalingsroute feitelijk stil gevallen."
     },
     {
@@ -204,6 +228,8 @@
       ],
       "aantal": 3,
       "is_gat": false,
+      "gat_soort": null,
+      "werk_in_uitvoering": [],
       "duiding": "Drie aanbieders plus een commerciele markt, voor een verplichting die per 15 augustus 2028 aantoonbaar moet zijn voor elk collegelid. Hier is overlap minder erg dan elders, want de doelgroep is groot en de capaciteit schaars."
     },
     {
@@ -215,6 +241,8 @@
       ],
       "aantal": 3,
       "is_gat": false,
+      "gat_soort": null,
+      "werk_in_uitvoering": [],
       "duiding": "Het Nederlands Security Meldpunt, waar de IBD sinds juni 2023 op aangesloten was, staat sinds april 2024 op non-actief. Artikel 17 Cbw wijst bij AMvB een coordinerend CSIRT aan. Openstaande vraag: via welk kanaal komt een melding na 15 augustus binnen, en wie leest dat?"
     },
     {
@@ -226,6 +254,8 @@
       ],
       "aantal": 3,
       "is_gat": false,
+      "gat_soort": null,
+      "werk_in_uitvoering": [],
       "duiding": "Drie partijen, drie verschillende rollen: NaWas scrubt maar vereist een eigen AS-nummer, de coalitie deelt fingerprints en oefent, het NCSC waarschuwt. Voor een gemeente loopt de scrubbing dus via de provider, en dat is een vraag die zelden gesteld wordt."
     },
     {
@@ -233,13 +263,20 @@
       "partijen": [],
       "aantal": 0,
       "is_gat": true,
-      "duiding": "CSIR 3.0 is niet verplicht gesteld, terecht want disproportioneel, en ISO 27001, 27002 en BIO2 zijn te generiek voor procesautomatisering. De VNG noemt dit letterlijk een normatief gat en werkt zelf aan baselines voor de 23 meest voorkomende OT-objecten. Raakt gemalen, bruggen, sluizen, verkeersregelinstallaties en gebouwbeheer."
+      "gat_soort": "werk_in_uitvoering",
+      "werk_in_uitvoering": [
+        "ibd",
+        "vng"
+      ],
+      "duiding": "CSIR 3.0 is niet verplicht gesteld, terecht want disproportioneel, en ISO 27001, 27002 en BIO2 zijn te generiek voor procesautomatisering. Er is dus geen vastgesteld kader, maar er wordt wel aan gewerkt: IBD en VNG maken objectbaselines voor de 23 meest voorkomende OT-objecten. Raakt gemalen, bruggen, sluizen, verkeersregelinstallaties en gebouwbeheer. Tijdpad en vorm (baseline per objecttype of annex op de BIO) zijn nog niet publiek."
     },
     {
       "dienst": "Landelijke weerbaarheidsmeting gemeenten",
       "partijen": [],
       "aantal": 0,
       "is_gat": true,
+      "gat_soort": "niets_belegd",
+      "werk_in_uitvoering": [],
       "duiding": "De Algemene Rekenkamer heeft geen mandaat over gemeenten, lokale rekenkamers leveren geen landelijk beeld, en ENSIA levert verantwoordingsdata maar geen analyse. Verzwarend: het Samenhangend Inspectiebeeld is in april 2025 voor twee jaar gepauzeerd."
     },
     {
@@ -247,13 +284,19 @@
       "partijen": [],
       "aantal": 0,
       "is_gat": true,
-      "duiding": "De voorzitter van het NDS-aanjaagteam prioriteit 5 zegt zelf dat de kwetsbaarheden vooral in de ketens tussen organisaties zitten. De WRR schreef dat in 2019 al. Versneller 5.4 is de eerste serieuze poging en heeft expliciet geen centraal register in scope."
+      "gat_soort": "werk_in_uitvoering",
+      "werk_in_uitvoering": [
+        "nds54"
+      ],
+      "duiding": "De voorzitter van het NDS-aanjaagteam prioriteit 5 zegt zelf dat de kwetsbaarheden vooral in de ketens tussen organisaties zitten. De WRR schreef dat in 2019 al. Niemand belegt de regie, maar versneller 5.4 is de eerste serieuze poging en levert een begrippenkader; een centraal register staat expliciet niet in scope."
     },
     {
       "dienst": "Opvolging van de OKTT-status",
       "partijen": [],
       "aantal": 0,
       "is_gat": true,
+      "gat_soort": "niets_belegd",
+      "werk_in_uitvoering": [],
       "duiding": "De OKTT-status was de wettelijke haak waarmee het NCSC informatie mocht delen buiten Rijk en vitaal. Die vervalt met de Cbw. Connect2Trust, NBIP, Ferm Zeehavens, CWB Brainport en Cyberveilig Nederland hangen eraan, en het CWN-bouwplan stelt vast dat de opvolging nog niet is uitgewerkt."
     }
   ]

--- a/security/stelselkaart-security-gremia/data/partijen.json
+++ b/security/stelselkaart-security-gremia/data/partijen.json
@@ -38,7 +38,7 @@
       }
     }
   },
-  "aantal": 82,
+  "aantal": 83,
   "partijen": [
     {
       "id": "enisa",
@@ -314,8 +314,8 @@
         "toez"
       ],
       "toegang_gemeente": "indirect",
-      "omschrijving": "Toezichthouder onder de Cyberbeveiligingswet voor gemeenten en provincies. Organiseert dat als interbestuurlijk toezicht: stelselgericht, leunend op ENSIA en BIO.",
-      "toelichting": "Geen wettelijke overgangstermijn: handhaving kan juridisch vanaf dag een. Bevoegde autoriteit voor de sector overheid is BZK."
+      "omschrijving": "Toezichthouder onder de Cyberbeveiligingswet voor gemeenten en provincies, namens BZK: BZK is de bevoegde autoriteit voor de sector overheid, de RDI voert het toezicht uit. Organiseert dat als interbestuurlijk toezicht: stelselgericht, leunend op ENSIA en BIO.",
+      "toelichting": "Geen wettelijke overgangstermijn: handhaving kan juridisch vanaf dag een. Dat de bevoegdheid bij BZK ligt en de uitvoering bij de RDI is bepalend voor waar een gemeente een vraag of melding kwijt kan."
     },
     {
       "id": "ilt",
@@ -986,6 +986,21 @@
       "toelichting": "Expliciet geen centraal register in scope. Werksessies 26 augustus, 9 en 16 september, afsluiting 21 september."
     },
     {
+      "id": "rsv",
+      "naam": "Regionale samenwerkingsverbanden (categorie)",
+      "laag": "reg",
+      "laag_label": "Regionaal",
+      "mandaat": "convenant",
+      "mandaat_label": "convenant of programma",
+      "functies": [
+        "cris",
+        "kenn"
+      ],
+      "toegang_gemeente": "indirect",
+      "omschrijving": "De categorie waar RSIV Den Haag een voorbeeld van is: regionale samenwerking tussen gemeenten rond integrale veiligheid en cyber, meestal op de schaal van een politie-eenheid (tien landelijk) of een veiligheidsregio (25).",
+      "toelichting": "Welke verbanden er precies bestaan, hoe ze heten en welke gemeenten erbuiten vallen is niet centraal in kaart gebracht; dit overzicht werkt er een uit en noemt de categorie als zodanig. Twee gevolgen: een gemeente kan niet nagaan of zij ergens bij hoort zonder het zelf uit te zoeken, en er is geen landelijk beeld van de dekking. Signaal uit de sector, augustus 2026: de dekking is breder dan het ene uitgewerkte verband."
+    },
+    {
       "id": "rsiv",
       "naam": "RSIV Den Haag",
       "laag": "reg",
@@ -997,7 +1012,7 @@
         "kenn"
       ],
       "toegang_gemeente": "direct",
-      "omschrijving": "Regionaal Samenwerkingsverband Integrale Veiligheid van 27 gemeenten in politie-eenheid Den Haag, plus OM en politie, onder de vlag Veiligheidscoalitie Den Haag.",
+      "omschrijving": "Regionaal Samenwerkingsverband Integrale Veiligheid van 27 gemeenten in politie-eenheid Den Haag, plus OM en politie, onder de vlag Veiligheidscoalitie Den Haag. Uitgewerkt voorbeeld van de categorie regionale samenwerkingsverbanden.",
       "toelichting": "Cybercrime is een van de vijf prioriteiten in het regionaal beleidsplan 2023-2026. Alle gemeenten in die politie-eenheid vallen eronder, van de bollenstreek tot de Krimpenerwaard. Invalshoek is openbare orde, dus de aansluiting loopt via OOV, niet via IV. Account aanvragen via rsiv@zoetermeer.nl."
     },
     {

--- a/security/stelselkaart-security-gremia/index.html
+++ b/security/stelselkaart-security-gremia/index.html
@@ -210,10 +210,13 @@ footer{margin-top:40px;padding-top:14px;border-top:1px solid var(--line);color:v
 </header>
 
 <div class="note" style="margin:16px 0 0">
-  <b>Open dataset uit de kennisbank van security-commons-nl.</b> 82 partijen en 19 concrete diensten die samen de
+  <b>Open dataset uit de kennisbank van security-commons-nl.</b> 83 partijen en 19 concrete diensten die samen de
   digitale weerbaarheid van de Nederlandse overheid organiseren. <b>Peildatum 11 augustus 2026</b>, vier dagen voor
-  inwerkingtreding van de Cyberbeveiligingswet: meerdere aanwijzingen waren toen nog niet rond. Klopt er iets niet
-  meer, mist er een partij, of wordt er al aan iets gewerkt dat hier als leeg staat?
+  inwerkingtreding van de Cyberbeveiligingswet: meerdere aanwijzingen waren toen nog niet rond. <b>Bijgewerkt
+  13 augustus 2026</b> na de eerste externe review uit de sector: de dienstentabel onderscheidt nu of iets
+  <i>niet is vastgesteld</i> of dat er <i>wel aan gewerkt wordt</i>, en regionale samenwerkingsverbanden staan er
+  als categorie in. Klopt er iets niet meer, mist er een partij, of wordt er al aan iets gewerkt dat hier als
+  leeg staat?
   <b>Twee routes:</b> <a href="https://github.com/security-commons-nl/kennisbank/issues/new/choose">open een issue</a> (kan met een paar regels, geen kennis van de
   data nodig) of <a href="https://github.com/security-commons-nl/kennisbank/edit/main/security/stelselkaart-security-gremia/data/partijen.json">wijzig een regel in de dataset</a> (GitHub maakt daar automatisch een
   voorstel van, jij hoeft geen schrijfrechten te hebben). De analyse van onnodige overlap en concurrentie is bewust
@@ -509,7 +512,7 @@ const P=[
 ["ndn","Nationaal Detectie Netwerk","rijk","convenant",["det"],"indirect","Gedeeld en verrijkt dreigingsbeeld van NCSC, AIVD, MIVD, rijksorganisaties en vitale aanbieders.","Deelname staat open voor rijksoverheid en vitale sectoren, niet voor gemeenten. De route loopt via de IBD als schakelorganisatie."],
 ["cyclotron","Cyclotron","rijk","convenant",["det","kenn"],"indirect","Publiek-privaat analyse- en duidingsplatform. Convenant getekend 30 september 2025 door 28 partijen, inmiddels circa veertig organisaties.","Deelnemers zijn diensten en securityleveranciers. Hier wordt de nationale duiding gemaakt die via NCSC en IBD jouw kant op komt."],
 ["hoc","House of Cyber","rijk","informeel",["kenn","opl"],"geen","Fysiek samenwerkingsgebouw in Den Haag Mariahoeve, het voormalige Aegon-hoofdkantoor. NCSC, Defensie, politie, NFI, HSD en TNO.","Geen juridische entiteit met eigen mandaat. Realisatie naar verwachting binnen enkele jaren, geen openingsdatum."],
-["rdi","RDI","rijk","wet",["toez"],"indirect","Toezichthouder onder de Cyberbeveiligingswet voor gemeenten en provincies. Organiseert dat als interbestuurlijk toezicht: stelselgericht, leunend op ENSIA en BIO.","Geen wettelijke overgangstermijn: handhaving kan juridisch vanaf dag een. Bevoegde autoriteit voor de sector overheid is BZK."],
+["rdi","RDI","rijk","wet",["toez"],"indirect","Toezichthouder onder de Cyberbeveiligingswet voor gemeenten en provincies, namens BZK: BZK is de bevoegde autoriteit voor de sector overheid, de RDI voert het toezicht uit. Organiseert dat als interbestuurlijk toezicht: stelselgericht, leunend op ENSIA en BIO.","Geen wettelijke overgangstermijn: handhaving kan juridisch vanaf dag een. Dat de bevoegdheid bij BZK ligt en de uitvoering bij de RDI is bepalend voor waar een gemeente een vraag of melding kwijt kan."],
 ["ilt","ILT","rijk","wet",["toez"],"geen","Toezichthouder onder de Cbw voor de waterschappen.","Relevant omdat gemeenten met waterschappen in de afvalwaterketen samenwerken en daar dus twee toezichtregimes samenkomen."],
 ["ap","Autoriteit Persoonsgegevens","rijk","wet",["toez"],"haal","Toezichthouder op de AVG. Bij een incident met persoonsgegevens loopt hier een eigen meldstroom naast de Cbw-melding.","Derde spoor naast NCSC-melding en aangifte bij de politie."],
 ["bzk","BZK","rijk","wet",["norm","kenn","opl"],"haal","Stelselverantwoordelijk voor BIO en ENSIA, bevoegde autoriteit voor de sector overheid, medeondertekenaar van het Bestuurlijk Convenant.","Concreet af te nemen: de Overheidsbrede Cyberoefening op 2 november 2026 (scenario gemeente Waaldam: regenval, IT-uitval en desinformatie) en 15 gratis webinars per jaar via ICTU."],
@@ -560,7 +563,8 @@ const P=[
 ["nds53","NDS 5.3 Continuiteit en BCM","rijk","convenant",["cris"],"haal","Versterken van continuiteit en wendbaarheid van kritieke dienstverlening, ISO 22301 gekoppeld aan ISO 27001 en de Cbw. Lead Marianne van den Boogaart (BZK).","Kernteam is Rijk-zwaar: BZK, IenW, UWV, P-Direkt. Kleinere organisaties met beperkte expertise zijn expliciet doelgroep, en dat zijn de gemeenten."],
 ["nds54","NDS 5.4 Inzicht kritieke dienstverlening","rijk","convenant",["norm"],"haal","Overheidsbreed inzicht in kritieke dienstverlening en de digitale bouwstenen, inclusief legacy. Penvoerder Robert Portegies (BZK).","Expliciet geen centraal register in scope. Werksessies 26 augustus, 9 en 16 september, afsluiting 21 september."],
 // ---- Regio ----
-["rsiv","RSIV Den Haag","reg","convenant",["cris","kenn"],"haal","Regionaal Samenwerkingsverband Integrale Veiligheid van 27 gemeenten in politie-eenheid Den Haag, plus OM en politie, onder de vlag Veiligheidscoalitie Den Haag.","Cybercrime is een van de vijf prioriteiten in het regionaal beleidsplan 2023-2026. Alle gemeenten in die politie-eenheid vallen eronder, van de bollenstreek tot de Krimpenerwaard. Invalshoek is openbare orde, dus de aansluiting loopt via OOV, niet via IV. Account aanvragen via rsiv@zoetermeer.nl."],
+["rsv","Regionale samenwerkingsverbanden (categorie)","reg","convenant",["cris","kenn"],"indirect","De categorie waar RSIV Den Haag een voorbeeld van is: regionale samenwerking tussen gemeenten rond integrale veiligheid en cyber, meestal op de schaal van een politie-eenheid (tien landelijk) of een veiligheidsregio (25).","Welke verbanden er precies bestaan, hoe ze heten en welke gemeenten erbuiten vallen is niet centraal in kaart gebracht; dit overzicht werkt er een uit en noemt de categorie als zodanig. Twee gevolgen: een gemeente kan niet nagaan of zij ergens bij hoort zonder het zelf uit te zoeken, en er is geen landelijk beeld van de dekking. Signaal uit de sector, augustus 2026: de dekking is breder dan het ene uitgewerkte verband."],
+["rsiv","RSIV Den Haag","reg","convenant",["cris","kenn"],"haal","Regionaal Samenwerkingsverband Integrale Veiligheid van 27 gemeenten in politie-eenheid Den Haag, plus OM en politie, onder de vlag Veiligheidscoalitie Den Haag. Uitgewerkt voorbeeld van de categorie regionale samenwerkingsverbanden.","Cybercrime is een van de vijf prioriteiten in het regionaal beleidsplan 2023-2026. Alle gemeenten in die politie-eenheid vallen eronder, van de bollenstreek tot de Krimpenerwaard. Invalshoek is openbare orde, dus de aansluiting loopt via OOV, niet via IV. Account aanvragen via rsiv@zoetermeer.nl."],
 ["pvo","PVO Regio Den Haag","reg","convenant",["kenn"],"geen","Platform Veilig Ondernemen, gefinancierd door JenV, bedient dezelfde 27 gemeenten. Doelgroep is het mkb.","De gemeente is medefinancier en partner, niet afnemer. Kanaal om lokale ondernemers te bereiken."],
 ["vrhm","Veiligheidsregio Hollands Midden","reg","vereniging",["cris"],"haal","Gemeenschappelijke regeling van gemeenten. Stelt elke vier jaar risicoprofiel, beleidsplan en crisisplan op.","Opgenomen als voorbeeld van de 25 veiligheidsregio's. Veiligheidsregio's vallen buiten de Cyberbeveiligingswet terwijl gemeenten er wel onder vallen, wat een gat achterlaat op de naad van de crisisorganisatie. De vierjaarlijkse planvorming (risicoprofiel, beleidsplan, crisisplan) is het moment waarop een gemeente de cyberdimensie kan inbrengen."],
 ["hr","Holland Rijnland","reg","vereniging",["inko"],"geen","Regionaal samenwerkingsorgaan van vijftien gemeenten. Geen security-uitvoeringsorganisatie.","Servicepunt71 is per 1 januari 2023 opgeheven en de bedrijfsvoering is overgegaan naar een centrumgemeente-constructie. Zo'n overgang verschuift de Cbw-entiteitsgrens: waar eerder de gemeenschappelijke regeling mogelijk zelfstandig entiteit was, ligt het gewicht daarna bij de gastheergemeente."],
@@ -723,11 +727,11 @@ const D=[
 ["DDoS-bescherming",["nbip","adc","ncsc"],
  "Drie partijen, drie verschillende rollen: NaWas scrubt maar vereist een eigen AS-nummer, de coalitie deelt fingerprints en oefent, het NCSC waarschuwt. Voor een gemeente loopt de scrubbing dus via de provider, en dat is een vraag die zelden gesteld wordt."],
 ["OT-normering",[],
- "CSIR 3.0 is niet verplicht gesteld, terecht want disproportioneel, en ISO 27001, 27002 en BIO2 zijn te generiek voor procesautomatisering. De VNG noemt dit letterlijk een normatief gat en werkt zelf aan baselines voor de 23 meest voorkomende OT-objecten. Raakt gemalen, bruggen, sluizen, verkeersregelinstallaties en gebouwbeheer."],
+ "CSIR 3.0 is niet verplicht gesteld, terecht want disproportioneel, en ISO 27001, 27002 en BIO2 zijn te generiek voor procesautomatisering. Er is dus geen vastgesteld kader, maar er wordt wel aan gewerkt: IBD en VNG maken objectbaselines voor de 23 meest voorkomende OT-objecten. Raakt gemalen, bruggen, sluizen, verkeersregelinstallaties en gebouwbeheer. Tijdpad en vorm (baseline per objecttype of annex op de BIO) zijn nog niet publiek.",["ibd","vng"]],
 ["Landelijke weerbaarheidsmeting gemeenten",[],
  "De Algemene Rekenkamer heeft geen mandaat over gemeenten, lokale rekenkamers leveren geen landelijk beeld, en ENSIA levert verantwoordingsdata maar geen analyse. Verzwarend: het Samenhangend Inspectiebeeld is in april 2025 voor twee jaar gepauzeerd."],
 ["Ketenregie tussen organisaties",[],
- "De voorzitter van het NDS-aanjaagteam prioriteit 5 zegt zelf dat de kwetsbaarheden vooral in de ketens tussen organisaties zitten. De WRR schreef dat in 2019 al. Versneller 5.4 is de eerste serieuze poging en heeft expliciet geen centraal register in scope."],
+ "De voorzitter van het NDS-aanjaagteam prioriteit 5 zegt zelf dat de kwetsbaarheden vooral in de ketens tussen organisaties zitten. De WRR schreef dat in 2019 al. Niemand belegt de regie, maar versneller 5.4 is de eerste serieuze poging en levert een begrippenkader; een centraal register staat expliciet niet in scope.",["nds54"]],
 ["Opvolging van de OKTT-status",[],
  "De OKTT-status was de wettelijke haak waarmee het NCSC informatie mocht delen buiten Rijk en vitaal. Die vervalt met de Cbw. Connect2Trust, NBIP, Ferm Zeehavens, CWB Brainport en Cyberveilig Nederland hangen eraan, en het CWN-bouwplan stelt vast dat de opvolging nog niet is uitgewerkt."]
 ];
@@ -735,12 +739,12 @@ const D=[
   const max=Math.max(...D.map(d=>d[1].length));
   let h='<div class="bandkop"><div>Concrete dienst</div><div>#</div><div>Wie het levert</div></div>';
   D.forEach(d=>{
-    const n=d[1].length, gap=n===0, hot=n>=5;
+    const n=d[1].length, gap=n===0, hot=n>=5, wip=d[3]||[];
     const w=gap?0:Math.round(n/max*100);
     const bg=gap?'':` style="background:linear-gradient(90deg,rgba(31,78,121,.07) ${w}%,rgba(31,78,121,0) ${w}%)"`;
     h+=`<div class="dr${gap?' gap':''}${hot?' hot':''}">`;
     h+=`<div class="dn">${d[0]}</div><div class="dc">${gap?'✖':n}</div>`;
-    h+=`<div class="dp"${bg}>${gap?'geen enkele partij belegt dit':d[1].map(id=>chip(id)).join('')}</div>`;
+    h+=`<div class="dp"${bg}>${gap?(wip.length?'niets vastgesteld, in ontwikkeling bij '+wip.map(id=>chip(id)).join(''):'geen enkele partij belegt dit'):d[1].map(id=>chip(id)).join('')}</div>`;
     h+=`<div class="dd">${d[2]}</div></div>`;
   });
   document.getElementById('band').innerHTML=h;


### PR DESCRIPTION
Drie aanscherpingen uit de eerste externe review op de dataset, plus dezelfde link-fix als in #17 maar nu in de README.

**1. Een nul betekende niet wat er stond.** Twee van de vier gaten hebben geen vastgesteld kader maar wel werk in uitvoering: OT-normering (IBD en VNG, objectbaselines voor 23 OT-objecten) en ketenregie (NDS 5.4, begrippenkader). De dienstenlaag heeft nu een optioneel vierde veld; in de JSON `gat_soort` (`niets_belegd` of `werk_in_uitvoering`) en `werk_in_uitvoering`. De weergave toont het onderscheid.

**2. RDI en BZK.** De RDI voert het toezicht uit, BZK is bevoegde autoriteit voor de sector overheid. Stond alleen in de toelichting, nu in de omschrijving.

**3. Regionale samenwerkingsverbanden als categorie**, met RSIV Den Haag als uitgewerkt voorbeeld, plus de constatering dat het landelijke beeld ontbreekt. Daarmee 83 partijen.

**README:** dezelfde relatieve-link-fout als in de pagina (GitHub maakte er `/blob/issues/new/choose` van), nu absolute URL's plus een directe editeer-link.

Gegenereerd via de vaste keten: interne bron → deelbaar → `data/*.json` en `index.html`. Vangnetten schoon, 0 em-dashes, 83 partijen / 19 diensten / 4 gaten waarvan 2 met werk in uitvoering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)