### PR TITLE
security: relatiegraaf aanvullen en OT-spoor een tijdpad geven

### DIFF
--- a/security/stelselkaart-security-gremia/README.md
+++ b/security/stelselkaart-security-gremia/README.md
@@ -17,6 +17,14 @@ van designated clubs als de IBD tot publiek-private platforms, plus de Europese 
 > samenwerkingsverbanden** zijn als categorie opgenomen, met RSIV Den Haag als uitgewerkt voorbeeld,
 > omdat er landelijk meer van zulke verbanden bestaan dan dat ene. Wat nog ontbreekt is het landelijke
 > beeld: welke verbanden er zijn en welke gemeenten erbuiten vallen.
+>
+> **Tweede ronde, dezelfde dag, na doorvragen op de plaat zelf.** De relatiegraaf miste een lijn van **BZK
+> naar de RDI**, terwijl de tekst al zei dat BZK bevoegd gezag is en de RDI het toezicht uitvoert; die staat
+> er nu in. **Gemeenschappelijke regelingen** ontbraken volledig als entiteitstype en staan nu als eigen blok
+> naast gemeente en regio, met hun Cbw-status als open vraag: een GR met eigen rechtspersoonlijkheid kan zelf
+> entiteit zijn, maar dat is nergens uitgewerkt terwijl een groot deel van de gemeentelijke uitvoering er zit.
+> **Privacy is bewust buiten scope gehouden**, ook al doen meerdere partijen hier beide; dat staat nu expliciet
+> in de verantwoording in plaats van dat het onbenoemd ontbreekt.
 
 ## Waarom dit bestaat
 
@@ -73,9 +81,10 @@ wordt overlap hard aanwijsbaar, en worden de gaten zichtbaar.
 gemeenten (de Algemene Rekenkamer heeft geen mandaat over gemeenten, lokale rekenkamers leveren geen
 landelijk beeld, ENSIA levert data maar geen analyse) en de opvolging van de OKTT-status (vervalt met de
 Cbw, opvolging niet uitgewerkt). Waar geen kader is vastgesteld maar wel aan gewerkt wordt: **OT-normering**
-(IBD en VNG maken objectbaselines voor de 23 meest voorkomende OT-objecten; tijdpad en vorm nog niet
-publiek) en **ketenregie tussen organisaties** (NDS-versneller 5.4 levert een begrippenkader, een centraal
-register staat expliciet niet in scope).
+(een expertgroep OT voor gemeenten vanuit de IBD heeft een opzet voor objectbaselines voor de 23 meest
+voorkomende OT-objecten in review; duidelijkheid verwacht rond eind september 2026) en **ketenregie tussen
+organisaties** (NDS-versneller 5.4 levert een begrippenkader, een centraal register staat expliciet niet in
+scope).
 
 Dat onderscheid is er sinds 13 augustus 2026 en het is geen detail: een nul in een tabel leest als "niemand
 doet iets", en dat deed het werk van anderen tekort.

--- a/security/stelselkaart-security-gremia/data/diensten.json
+++ b/security/stelselkaart-security-gremia/data/diensten.json
@@ -268,7 +268,7 @@
         "ibd",
         "vng"
       ],
-      "duiding": "CSIR 3.0 is niet verplicht gesteld, terecht want disproportioneel, en ISO 27001, 27002 en BIO2 zijn te generiek voor procesautomatisering. Er is dus geen vastgesteld kader, maar er wordt wel aan gewerkt: IBD en VNG maken objectbaselines voor de 23 meest voorkomende OT-objecten. Raakt gemalen, bruggen, sluizen, verkeersregelinstallaties en gebouwbeheer. Tijdpad en vorm (baseline per objecttype of annex op de BIO) zijn nog niet publiek."
+      "duiding": "CSIR 3.0 is niet verplicht gesteld, terecht want disproportioneel, en ISO 27001, 27002 en BIO2 zijn te generiek voor procesautomatisering. Er is dus geen vastgesteld kader, maar er wordt wel aan gewerkt: een expertgroep OT voor gemeenten, getrokken vanuit de IBD, heeft een opzet voor objectbaselines in review liggen voor de 23 meest voorkomende OT-objecten. Duidelijkheid wordt verwacht rond eind september 2026 (opgave van de trekkers, augustus 2026). Raakt gemalen, bruggen, sluizen, verkeersregelinstallaties en gebouwbeheer."
     },
     {
       "dienst": "Landelijke weerbaarheidsmeting gemeenten",

--- a/security/stelselkaart-security-gremia/index.html
+++ b/security/stelselkaart-security-gremia/index.html
@@ -351,7 +351,13 @@ footer{margin-top:40px;padding-top:14px;border-top:1px solid var(--line);color:v
   <div class="lead">Deze kaart is opgebouwd uit zes parallelle onderzoeksronden, elk over een eigen deel van het
   veld, plus een toets vanuit de dagelijkse praktijk van een gemeentelijke CISO: klopt het beeld met hoe het er van
   binnenuit uitziet. Waar bronnen elkaar tegenspreken is dat hieronder expliciet benoemd in plaats van
-  gladgestreken.</div>
+  gladgestreken.<br><br><b>Scope.</b> Dit gaat over wie de digitale weerbaarheid van de overheid organiseert.
+  <b>Privacy is bewust buiten scope gehouden</b>, ook al doen meerdere partijen hier beide: het meenemen van dat
+  domein vraagt om de toezichthouder, de FG-netwerken en de beroepsorganisaties erbij, en dat maakt er een ander
+  overzicht van. Waar een partij ook een privacytaak heeft, staat dat in de toelichting bij die partij.<br><br>
+  <b>Opgesteld met AI-ondersteuning</b>, met de feiten geverifieerd op de bronnen die per partij vermeld staan.
+  De dataset en de leesbare weergave worden gegenereerd uit één bron, zodat cijfers en tekst niet uit elkaar
+  kunnen lopen.</div>
 
   <h2>Hoe dit is samengesteld</h2>
   <p>Het onderzoek liep in zes parallelle ronden, elk over een eigen deel van het veld, plus een ronde over de
@@ -645,17 +651,18 @@ const chip=(id,extra="")=>{const r=byId[id];if(!r)return"";
     {id:"ggi",l:"GGI-Veilig",s:"inkoopmantel",x:800,y:384,w:130,h:36,c:"#2e7d68"},
     {id:"vrhm",l:"VRHM",s:"buiten de Cbw",x:60,y:384,w:130,h:36,c:"#8b1a1a"},
     {id:"rsiv",l:"RSIV Den Haag",s:"27 gemeenten, OOV",x:250,y:384,w:160,h:36,c:"#a06a2c"},
-    {id:"gem",l:"Gemeente en regio",s:"essentiele entiteit",x:430,y:472,w:220,h:44,c:"#0b6b3a"}
+    {id:"gem",l:"Gemeente en regio",s:"essentiele entiteit",x:390,y:472,w:220,h:44,c:"#0b6b3a"},
+    {id:"gr",l:"Gemeenschappelijke regelingen",s:"eigen entiteit? niet uitgewerkt",x:680,y:472,w:240,h:44,c:"#8b1a1a"}
   ];
   const E=[
     ["eu","jenv","stuurt"],["eu","bzk","stuurt"],
     ["jenv","ncsc","stuurt"],["jenv","rdi","toezicht"],
-    ["bzk","cip","beheer"],["bzk","vng","betaalt"],["bzk","nds","trekt"],
+    ["bzk","cip","beheer"],["bzk","vng","betaalt"],["bzk","nds","trekt"],["bzk","rdi","bevoegd gezag"],
     ["ncsc","ibd","informeert"],["ncsc","c2t","informeert"],["ncsc","gem","CSIRT sinds 15-08"],
     ["cip","vng","normen"],["vng","ibd","eigenaar"],["vng","ensia","beheert"],["vng","ggi","mantel"],
     ["ibd","gem","advies"],["c2t","gem","dreigingsinfo"],["ggi","gem","diensten"],
     ["ensia","gem","verantwoording"],["rdi","gem","toezicht"],["nds","gem","versnellers"],
-    ["vrhm","gem","warme fase"],["rsiv","gem","openbare orde"]
+    ["vrhm","gem","warme fase"],["rsiv","gem","openbare orde"],["gem","gr","taken belegd"]
   ];
   const pos=Object.fromEntries(N.map(n=>[n.id,n]));
   const cx=n=>n.x+n.w/2, cy=n=>n.y+n.h/2;
@@ -727,7 +734,7 @@ const D=[
 ["DDoS-bescherming",["nbip","adc","ncsc"],
  "Drie partijen, drie verschillende rollen: NaWas scrubt maar vereist een eigen AS-nummer, de coalitie deelt fingerprints en oefent, het NCSC waarschuwt. Voor een gemeente loopt de scrubbing dus via de provider, en dat is een vraag die zelden gesteld wordt."],
 ["OT-normering",[],
- "CSIR 3.0 is niet verplicht gesteld, terecht want disproportioneel, en ISO 27001, 27002 en BIO2 zijn te generiek voor procesautomatisering. Er is dus geen vastgesteld kader, maar er wordt wel aan gewerkt: IBD en VNG maken objectbaselines voor de 23 meest voorkomende OT-objecten. Raakt gemalen, bruggen, sluizen, verkeersregelinstallaties en gebouwbeheer. Tijdpad en vorm (baseline per objecttype of annex op de BIO) zijn nog niet publiek.",["ibd","vng"]],
+ "CSIR 3.0 is niet verplicht gesteld, terecht want disproportioneel, en ISO 27001, 27002 en BIO2 zijn te generiek voor procesautomatisering. Er is dus geen vastgesteld kader, maar er wordt wel aan gewerkt: een expertgroep OT voor gemeenten, getrokken vanuit de IBD, heeft een opzet voor objectbaselines in review liggen voor de 23 meest voorkomende OT-objecten. Duidelijkheid wordt verwacht rond eind september 2026 (opgave van de trekkers, augustus 2026). Raakt gemalen, bruggen, sluizen, verkeersregelinstallaties en gebouwbeheer.",["ibd","vng"]],
 ["Landelijke weerbaarheidsmeting gemeenten",[],
  "De Algemene Rekenkamer heeft geen mandaat over gemeenten, lokale rekenkamers leveren geen landelijk beeld, en ENSIA levert verantwoordingsdata maar geen analyse. Verzwarend: het Samenhangend Inspectiebeeld is in april 2025 voor twee jaar gepauzeerd."],
 ["Ketenregie tussen organisaties",[],


### PR DESCRIPTION
Tweede ronde uit dezelfde externe review, nu op de plaat in plaats van op de tekst.

- **BZK → RDI ontbrak in de relatiegraaf**, terwijl de tekstlaag al zei dat BZK bevoegd gezag is en de RDI uitvoert. De graaf sprak de tekst tegen; die lijn staat er nu in.
- **Gemeenschappelijke regelingen ontbraken als entiteitstype.** Nu een eigen blok naast gemeente en regio, met de open vraag erbij: een GR met eigen rechtspersoonlijkheid kan zelf entiteit zijn onder de Cbw, maar dat is nergens uitgewerkt.
- **OT-spoor heeft een tijdpad**: expertgroep OT voor gemeenten heeft een opzet voor objectbaselines in review, duidelijkheid verwacht rond eind september 2026.
- **Scope expliciet gemaakt**: privacy bewust buiten scope, en de AI-ondersteuning met bronverificatie staat nu in de verantwoording in plaats van alleen in de voettekst.

Gegenereerd via de vaste keten. Vangnetten schoon, 0 em-dashes, 83 partijen / 19 diensten / 4 gaten waarvan 2 met werk in uitvoering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)