### PR TITLE
overig/beleid: per beleidsstuk een eigen map (ai-beleid/)

### DIFF
--- a/overig/beleid/README.md
+++ b/overig/beleid/README.md
@@ -3,83 +3,27 @@
 Vastgestelde en concept-beleidsstukken die als voorbeeld of vertrekpunt bruikbaar zijn voor andere
 publieke organisaties. Geanonimiseerd, met placeholders op de plek van de eigen organisatie.
 
-## Wat je hier vindt
+Beleid dat wél onder een eigen domein valt staat daar en niet hier: informatiebeveiligingsbeleid in
+[`security/`](../../security/), privacybeleid in [`privacy/`](../../privacy/), BCM-beleid in
+[`bcm/`](../../bcm/).
 
-| Bestand | Inhoud |
+## Wat staat hier
+
+| Map | Onderwerp |
 |---|---|
-| **[`index.html`](index.html)** | **De leesbare weergave.** Open het bestand in je browser, of via GitHub Pages direct de map-URL. Offline te openen, geen externe afhankelijkheden |
-| [`ai-beleid-regio.md`](ai-beleid-regio.md) | Dezelfde tekst als markdown, om uit te knippen, aan te passen of te diffen |
+| [`ai-beleid/`](ai-beleid/) | AI-beleid van een regionale samenwerking van vier gemeenten. Concept v1.0: waarden, juridische kaders, governance en rollen, risicobeheersing, gebruiksregels, transparantie en AI-geletterdheid, plus het rollenoverzicht uit het VNG AI-Governancekader en een begrippenlijst |
 
----
+## Conventie
 
-## AI-beleid van een regionale samenwerking
+Eén map per beleidsstuk, met daarin:
 
-Een compleet AI-beleid voor een samenwerkingsverband van vier gemeenten: waarden, juridische kaders,
-governance en rollen, risicobeheersing, gebruiksregels, transparantie en AI-geletterdheid. Acht
-hoofdstukken plus twee bijlagen (het volledige rollenoverzicht uit het VNG AI-Governancekader en een
-begrippenlijst).
+- `README.md` met de herkomst, de vertaalsleutel voor de placeholders en wat er bij hergebruik nagelopen
+  moet worden
+- `index.html` als leesbare weergave, offline te openen en zonder externe afhankelijkheden
+- het beleidsstuk zelf als markdown, om uit te knippen, aan te passen of te diffen
 
-Status van het origineel: **concept, versie 1.0**, met de gemeentesecretaris als ambtelijk eigenaar en
-het college als bestuurlijk eigenaar. Het is dus geen vastgesteld beleid maar een uitgewerkt concept, en
-dat is precies wat het bruikbaar maakt om naast je eigen traject te leggen.
+## Bijdragen
 
-### Waarom dit hier staat
-
-De meeste gemeenten schrijven op dit moment hun eerste AI-beleid, met dezelfde vragen: hoe verhoudt dit
-zich tot de AI Act, wat leg je vast in beleid en wat in een plan van aanpak, welke rollen richt je in, en
-hoe voorkom je dat het bij principes blijft. Dit stuk maakt die keuzes expliciet in plaats van ze open te
-laten. Een paar dingen die er inhoudelijk uit springen:
-
-- **De waarden zijn aan een beslismoment gekoppeld** (paragraaf 2.6). Ieder AI-systeem moet langs een
-  vaste set vragen voordat het project start, en een ethische dialoogtafel kan adviseren de inzet niet
-  door te zetten, ook als die technisch en financieel haalbaar is.
-- **Botsende waarden worden vooraf opgeschreven.** Bij elk nieuw systeem wordt vastgelegd welke waarden
-  met elkaar in conflict zijn en welke afweging is gemaakt. Dat maakt de spanning onderdeel van de
-  besluitvorming in plaats van iets dat later opduikt.
-- **Een drielagenmodel voor tools** (paragraaf 6.4): verboden, ongeautoriseerd-maar-niet-verboden, en
-  geautoriseerd-en-geclassificeerd. De middelste laag erkent dat medewerkers experimenteren en geeft daar
-  regels voor, in plaats van te doen alsof dat niet gebeurt.
-- **Expliciet géén enkele geautoriseerde AI.** Mede vanuit digitale soevereiniteit worden meerdere
-  alternatieven aangeboden, met een keuzehulp.
-- **De arbeidsmarktkant is belegd.** De inzet van AI is nooit alleen een bedrijfseconomische afweging; er
-  komt samen met de ondernemingsraden een afwegingskader voor werkgelegenheidseffecten, met bijzondere
-  aandacht voor werk dat is toegewezen aan medewerkers met een afstand tot de arbeidsmarkt.
-- **Beperkte black box wordt geaccepteerd, maar alleen waar het mag** (paragraaf 7.3). Geen black box bij
-  besluiten over inwoners; wel een beperkte mate bij ondersteunend gebruik van taalmodellen, mits de
-  medewerker controleert en bronnen verifieert.
-
-### Anonimisering en vertaalsleutel
-
-Het document is geanonimiseerd. Placeholders staan in hoofdletters, zodat je ze met zoek-en-vervang kunt
-invullen:
-
-| Placeholder | Wat je invult |
-|---|---|
-| `DE REGIO` | Je eigen samenwerkingsverband of organisatie |
-| `VOORBEELDGEMEENTE` | De centrumgemeente of hoofdorganisatie |
-| `GEMEENTE B`, `GEMEENTE C`, `GEMEENTE D` | De deelnemende organisaties |
-| `VASTSTELLINGSDATUM` | De datum van vaststelling |
-| `AI@REGIO.nl` | Het eigen vragenpostbus-adres |
-
-Daarnaast zijn interne proces- en gremiumnamen vervangen door generieke termen: het *portfolioproces*
-(intakeproces voor informatievoorzieningswensen), het *AI-register* (intern register van geautoriseerde
-AI-systemen, breder dan het wettelijke Algoritmeregister), de *ethische dialoogtafel*, het
-*AI-kennisnetwerk* en het *AI-kernteam*. Rolnamen zijn genormaliseerd naar de *AI-compliance officer*.
-Vervang ze door je eigen benamingen waar die afwijken.
-
-> **Let op bij hergebruik.** Dit is een concept van één regio, geen norm en geen model dat door VNG of een
-> toezichthouder is vastgesteld. Verwijzingen naar interne kaders (privacybeleid,
-> informatiebeveiligingsbeleid, handreiking AI, beleid gedeelde verantwoordelijkheid applicaties,
-> GIBIT-voorwaarden) verwijzen naar documenten van de oorspronkelijke organisatie. Loop ze na tegen je
-> eigen situatie voordat je de tekst overneemt.
-
-### Bijlage 1 is overgenomen materiaal
-
-Het rollenoverzicht in bijlage 1 komt uit *Welke rollen krijgen te maken met AI en algoritmen?* van het
-VNG AI-Governancekader. Het is hier opgenomen omdat het beleid ernaar verwijst; de raadpleegdatum is bij
-anonimisering verwijderd. Raadpleeg de VNG-bron voor de actuele versie.
-
-## Licentie
-
-[EUPL-1.2](../../LICENSE), vrij te hergebruiken en aan te passen. Feedback en verbeteringen welkom via de
-[kennisbank](../../).
+Zie [CONTRIBUTING.md](../../CONTRIBUTING.md) voor instructies. Anonimiseer vóór het indienen: geen namen,
+e-mailadressen, interne systeem-URL's of andere persoonsgegevens. Let daarbij op zoek-en-vervang die te
+grof is; in het eerste stuk hier was het werkwoord *leiden* meevervangen door de plaatsnaam.

--- a/overig/beleid/ai-beleid/README.md
+++ b/overig/beleid/ai-beleid/README.md
@@ -1,0 +1,85 @@
+# Beleid
+
+Vastgestelde en concept-beleidsstukken die als voorbeeld of vertrekpunt bruikbaar zijn voor andere
+publieke organisaties. Geanonimiseerd, met placeholders op de plek van de eigen organisatie.
+
+## Wat je hier vindt
+
+| Bestand | Inhoud |
+|---|---|
+| **[`index.html`](index.html)** | **De leesbare weergave.** Open het bestand in je browser, of via GitHub Pages direct de map-URL. Offline te openen, geen externe afhankelijkheden |
+| [`ai-beleid-regio.md`](ai-beleid-regio.md) | Dezelfde tekst als markdown, om uit te knippen, aan te passen of te diffen |
+
+---
+
+## AI-beleid van een regionale samenwerking
+
+Een compleet AI-beleid voor een samenwerkingsverband van vier gemeenten: waarden, juridische kaders,
+governance en rollen, risicobeheersing, gebruiksregels, transparantie en AI-geletterdheid. Acht
+hoofdstukken plus twee bijlagen (het volledige rollenoverzicht uit het VNG AI-Governancekader en een
+begrippenlijst).
+
+Status van het origineel: **concept, versie 1.0**, met de gemeentesecretaris als ambtelijk eigenaar en
+het college als bestuurlijk eigenaar. Het is dus geen vastgesteld beleid maar een uitgewerkt concept, en
+dat is precies wat het bruikbaar maakt om naast je eigen traject te leggen.
+
+### Waarom dit hier staat
+
+De meeste gemeenten schrijven op dit moment hun eerste AI-beleid, met dezelfde vragen: hoe verhoudt dit
+zich tot de AI Act, wat leg je vast in beleid en wat in een plan van aanpak, welke rollen richt je in, en
+hoe voorkom je dat het bij principes blijft. Dit stuk maakt die keuzes expliciet in plaats van ze open te
+laten. Een paar dingen die er inhoudelijk uit springen:
+
+- **De waarden zijn aan een beslismoment gekoppeld** (paragraaf 2.6). Ieder AI-systeem moet langs een
+  vaste set vragen voordat het project start, en een ethische dialoogtafel kan adviseren de inzet niet
+  door te zetten, ook als die technisch en financieel haalbaar is.
+- **Botsende waarden worden vooraf opgeschreven.** Bij elk nieuw systeem wordt vastgelegd welke waarden
+  met elkaar in conflict zijn en welke afweging is gemaakt. Dat maakt de spanning onderdeel van de
+  besluitvorming in plaats van iets dat later opduikt.
+- **Een drielagenmodel voor tools** (paragraaf 6.4): verboden, ongeautoriseerd-maar-niet-verboden, en
+  geautoriseerd-en-geclassificeerd. De middelste laag erkent dat medewerkers experimenteren en geeft daar
+  regels voor, in plaats van te doen alsof dat niet gebeurt.
+- **Expliciet géén enkele geautoriseerde AI.** Mede vanuit digitale soevereiniteit worden meerdere
+  alternatieven aangeboden, met een keuzehulp.
+- **De arbeidsmarktkant is belegd.** De inzet van AI is nooit alleen een bedrijfseconomische afweging; er
+  komt samen met de ondernemingsraden een afwegingskader voor werkgelegenheidseffecten, met bijzondere
+  aandacht voor werk dat is toegewezen aan medewerkers met een afstand tot de arbeidsmarkt.
+- **Beperkte black box wordt geaccepteerd, maar alleen waar het mag** (paragraaf 7.3). Geen black box bij
+  besluiten over inwoners; wel een beperkte mate bij ondersteunend gebruik van taalmodellen, mits de
+  medewerker controleert en bronnen verifieert.
+
+### Anonimisering en vertaalsleutel
+
+Het document is geanonimiseerd. Placeholders staan in hoofdletters, zodat je ze met zoek-en-vervang kunt
+invullen:
+
+| Placeholder | Wat je invult |
+|---|---|
+| `DE REGIO` | Je eigen samenwerkingsverband of organisatie |
+| `VOORBEELDGEMEENTE` | De centrumgemeente of hoofdorganisatie |
+| `GEMEENTE B`, `GEMEENTE C`, `GEMEENTE D` | De deelnemende organisaties |
+| `VASTSTELLINGSDATUM` | De datum van vaststelling |
+| `AI@REGIO.nl` | Het eigen vragenpostbus-adres |
+
+Daarnaast zijn interne proces- en gremiumnamen vervangen door generieke termen: het *portfolioproces*
+(intakeproces voor informatievoorzieningswensen), het *AI-register* (intern register van geautoriseerde
+AI-systemen, breder dan het wettelijke Algoritmeregister), de *ethische dialoogtafel*, het
+*AI-kennisnetwerk* en het *AI-kernteam*. Rolnamen zijn genormaliseerd naar de *AI-compliance officer*.
+Vervang ze door je eigen benamingen waar die afwijken.
+
+> **Let op bij hergebruik.** Dit is een concept van één regio, geen norm en geen model dat door VNG of een
+> toezichthouder is vastgesteld. Verwijzingen naar interne kaders (privacybeleid,
+> informatiebeveiligingsbeleid, handreiking AI, beleid gedeelde verantwoordelijkheid applicaties,
+> GIBIT-voorwaarden) verwijzen naar documenten van de oorspronkelijke organisatie. Loop ze na tegen je
+> eigen situatie voordat je de tekst overneemt.
+
+### Bijlage 1 is overgenomen materiaal
+
+Het rollenoverzicht in bijlage 1 komt uit *Welke rollen krijgen te maken met AI en algoritmen?* van het
+VNG AI-Governancekader. Het is hier opgenomen omdat het beleid ernaar verwijst; de raadpleegdatum is bij
+anonimisering verwijderd. Raadpleeg de VNG-bron voor de actuele versie.
+
+## Licentie
+
+[EUPL-1.2](../../../LICENSE), vrij te hergebruiken en aan te passen. Feedback en verbeteringen welkom via de
+[kennisbank](../../../).

--- a/overig/beleid/ai-beleid/ai-beleid-regio.md
+++ b/overig/beleid/ai-beleid/ai-beleid-regio.md
@@ -4,7 +4,7 @@
 > zijn vervangen door placeholders in hoofdletters (`DE REGIO`, `VOORBEELDGEMEENTE`, `GEMEENTE B` tot en
 > met `GEMEENTE D`). Het stuk is bedoeld om hergebruikt te worden: zoek de placeholders op en vul je
 > eigen organisatie in. Zie het
-> [README](https://github.com/security-commons-nl/kennisbank/tree/main/overig/beleid) voor de herkomst
+> [README](https://github.com/security-commons-nl/kennisbank/tree/main/overig/beleid/ai-beleid) voor de herkomst
 > en de vertaalsleutel.
 
 | | |

--- a/overig/beleid/ai-beleid/index.html
+++ b/overig/beleid/ai-beleid/index.html
@@ -50,7 +50,7 @@
 </div></header>
 <main>
 <blockquote>
-<p><strong>Geanonimiseerd voorbeelddocument.</strong> Organisatienamen, rolhouders, procesnamen en contactgegevens zijn vervangen door placeholders in hoofdletters (<code>DE REGIO</code>, <code>VOORBEELDGEMEENTE</code>, <code>GEMEENTE B</code> tot en met <code>GEMEENTE D</code>). Het stuk is bedoeld om hergebruikt te worden: zoek de placeholders op en vul je eigen organisatie in. Zie het <a href="https://github.com/security-commons-nl/kennisbank/tree/main/overig/beleid">README</a> voor de herkomst en de vertaalsleutel.</p>
+<p><strong>Geanonimiseerd voorbeelddocument.</strong> Organisatienamen, rolhouders, procesnamen en contactgegevens zijn vervangen door placeholders in hoofdletters (<code>DE REGIO</code>, <code>VOORBEELDGEMEENTE</code>, <code>GEMEENTE B</code> tot en met <code>GEMEENTE D</code>). Het stuk is bedoeld om hergebruikt te worden: zoek de placeholders op en vul je eigen organisatie in. Zie het <a href="https://github.com/security-commons-nl/kennisbank/tree/main/overig/beleid/ai-beleid">README</a> voor de herkomst en de vertaalsleutel.</p>
 </blockquote>
 <div class="tablewrap"><table>
 


### PR DESCRIPTION
Vervolg op #20. `beleid/` was daar zelf de bijdrage; het hoort een **categorie** te zijn met per beleidsstuk een eigen map, zoals `security/` dat ook doet.

```
overig/beleid/
├── README.md          categorie-index + conventie
└── ai-beleid/
    ├── README.md      herkomst, vertaalsleutel, hergebruik
    ├── ai-beleid-regio.md
    └── index.html
```

Meeverhuisd: de relatieve links naar `LICENSE` en de repo-root gaan een niveau dieper, de GitHub-URL in het beleidsstuk zelf wijst nu naar de nieuwe map, en `index.html` is opnieuw gegenereerd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qhdjNkYWESFYQwyAEBKkG
