### PR TITLE
governance: AI-beleid verwijst door naar het draaiboek AI-gebruik in beeld

### DIFF
--- a/governance/ai-beleid/README.md
+++ b/governance/ai-beleid/README.md
@@ -92,6 +92,18 @@ Het rollenoverzicht in bijlage 1 komt uit *Welke rollen krijgen te maken met AI 
 VNG AI-Governancekader. Het is hier opgenomen omdat het beleid ernaar verwijst; de raadpleegdatum is bij
 anonimisering verwijderd. Raadpleeg de VNG-bron voor de actuele versie.
 
+## Hoe dit samenhangt met de andere stukken
+
+Beleid vaststellen is een ding, weten wat er feitelijk draait is een ander. Het drielagenmodel in
+paragraaf 6.4 (verboden, ongeautoriseerd-maar-niet-verboden, geautoriseerd-en-geclassificeerd)
+veronderstelt dat je weet welke tools er in de organisatie gebruikt worden. Zonder feitenbeeld is die
+middelste laag een aanname.
+
+| Wil je | Ga naar |
+|---|---|
+| AI-gebruik in je organisatie feitelijk meten voordat je beleid vaststelt | [AI-gebruik in beeld](https://security-commons-nl.github.io/ai-gebruik-in-beeld/) |
+| De methode achter dat meten: eerst vaststellen, dan pas afdwingen | [Meten voordat je ingrijpt](../../security/meten-voordat-je-ingrijpt/) |
+
 ## Licentie
 
 [EUPL-1.2](../../LICENSE), vrij te hergebruiken en aan te passen. Feedback en verbeteringen welkom via de

--- a/governance/ai-beleid/ai-beleid-regio.md
+++ b/governance/ai-beleid/ai-beleid-regio.md
@@ -6,6 +6,10 @@
 > eigen organisatie in. Zie het
 > [README](https://github.com/security-commons-nl/kennisbank/tree/main/governance/ai-beleid) voor de herkomst
 > en de vertaalsleutel.
+>
+> Wil je eerst vaststellen wat er in je eigen organisatie feitelijk aan AI draait voordat je dit beleid
+> overneemt, gebruik dan het draaiboek
+> [AI-gebruik in beeld](https://security-commons-nl.github.io/ai-gebruik-in-beeld/).
 
 | | |
 |---|---|

--- a/governance/ai-beleid/index.html
+++ b/governance/ai-beleid/index.html
@@ -53,6 +53,7 @@
 <p class="bron">Deze tekst als markdown-bron: <a href="ai-beleid-regio.md">ai-beleid-regio.md</a></p>
 <blockquote>
 <p><strong>Geanonimiseerd voorbeelddocument.</strong> Organisatienamen, rolhouders, procesnamen en contactgegevens zijn vervangen door placeholders in hoofdletters (<code>DE REGIO</code>, <code>VOORBEELDGEMEENTE</code>, <code>GEMEENTE B</code> tot en met <code>GEMEENTE D</code>). Het stuk is bedoeld om hergebruikt te worden: zoek de placeholders op en vul je eigen organisatie in. Zie het <a href="https://github.com/security-commons-nl/kennisbank/tree/main/governance/ai-beleid">README</a> voor de herkomst en de vertaalsleutel.</p>
+<p>Wil je eerst vaststellen wat er in je eigen organisatie feitelijk aan AI draait voordat je dit beleid overneemt, gebruik dan het draaiboek <a href="https://security-commons-nl.github.io/ai-gebruik-in-beeld/">AI-gebruik in beeld</a>.</p>
 </blockquote>
 <div class="tablewrap"><table>
 


### PR DESCRIPTION
Het AI-beleid gaat uit van een drielagenmodel voor tools (paragraaf 6.4), maar de middelste laag veronderstelt dat je weet wat er feitelijk draait. `Meten voordat je ingrijpt` verwees al naar het draaiboek `ai-gebruik-in-beeld`; andersom nog niet.

De verwijzing staat op drie plekken, omdat de leesversie van dit item het brondocument toont en niet de README: een wijziging in alleen de README zou de lezer op github.io nooit bereiken.

- `README.md`: nieuwe sectie *Hoe dit samenhangt met de andere stukken*
- `ai-beleid-regio.md`: een alinea in de bestaande redactionele blockquote bovenaan
- `index.html`: dezelfde alinea in de leesversie

Lokaal groen: `test_build.py` (28), `test_handleidingen.py` (20), `build.py --check` geen overtredingen over 49 items.

Let op: `index.html` is met de hand bijgewerkt en niet met pandoc gegenereerd (staat niet op de machine waar dit vandaan komt).